### PR TITLE
handle wider variety of timestamp and attachment formats

### DIFF
--- a/wacb/WhatsAppParser.rb
+++ b/wacb/WhatsAppParser.rb
@@ -38,10 +38,12 @@ module WhatsAppChatBeautifier
       # unicode character.
       #
 
-      timestampMatch = messageLine.match('(\[)?(\d{2}.\d{2}.\d{2}, \d{2}:\d{2}:\d{2})(\])?(:)?')
+      timestampMatch = messageLine.match('(\[)?(\d{1,2}.\d{1,2}.\d{1,2}, \d{1,2}:\d{1,2}:\d{1,2})(\])?(:)?')
       raise "Line does not start with a timestamp: \"#{messageLine}\"" if timestampMatch == nil
 
-      timestamp = DateTime.strptime(timestampMatch[2].strip, "%d.%m.%y, %H:%M:%S")
+      timestamp = DateTime.strptime(timestampMatch[2].strip
+                                      .gsub(/\//, { '/' => '.' }),
+                                    "%d.%m.%y, %H:%M:%S")
 
       #
       # After the timestamp, there is usually the sender ID followed by a ":",
@@ -77,13 +79,17 @@ module WhatsAppChatBeautifier
       # export feature.
       #
 
-      attachmentMatch = message.match('([0-9A-Za-z\- ]+\.[A-Za-z0-9]+).*<[^\s>]+>')
+      for attachmentRegex in ['([0-9A-Za-z\- ]+\.[A-Za-z0-9]+).*<[^\s>]+>',
+                              '<attached: (\S+)>'] do
+        attachmentMatch = message.match(attachmentRegex)
 
-      if attachmentMatch != nil
-        message = nil
-        attachmentFileName = attachmentMatch[1]
-      else
-        attachmentFileName = nil
+        if attachmentMatch != nil
+          message = nil
+          attachmentFileName = attachmentMatch[1]
+          break
+        else
+          attachmentFileName = nil
+        end
       end
 
       return {

--- a/wacb/WhatsAppParser.rb
+++ b/wacb/WhatsAppParser.rb
@@ -44,7 +44,6 @@ module WhatsAppChatBeautifier
       # I'm guessing exports are locale-specific so some amount of massaging is needed
       timestampRaw = timestampMatch[2].strip.gsub(/\//, { '/' => '.' })
 
-
       # TODO: add command-line option to specify if we are DD/MM/YY or MM/DD/YY;
       # or just deduce it by scanning the chat file looking for MM >12
       if timestampMatch[3] != nil
@@ -54,7 +53,6 @@ module WhatsAppChatBeautifier
       end
 
       timestamp = DateTime.strptime(timestampRaw, strpFormat)
-      puts "parsed " + timestamp.inspect
      
       #
       # After the timestamp, there is usually the sender ID followed by a ":",

--- a/wacb/WhatsAppParser.rb
+++ b/wacb/WhatsAppParser.rb
@@ -38,13 +38,24 @@ module WhatsAppChatBeautifier
       # unicode character.
       #
 
-      timestampMatch = messageLine.match('(\[)?(\d{1,2}.\d{1,2}.\d{1,2}, \d{1,2}:\d{1,2}:\d{1,2})(\])?(:)?')
+      timestampMatch = messageLine.match('(\[)?(\d{1,2}.\d{1,2}.\d{1,2}, \d{1,2}:\d{1,2}:\d{1,2}( [AP]M)?)(\])?(:)?')
       raise "Line does not start with a timestamp: \"#{messageLine}\"" if timestampMatch == nil
 
-      timestamp = DateTime.strptime(timestampMatch[2].strip
-                                      .gsub(/\//, { '/' => '.' }),
-                                    "%d.%m.%y, %H:%M:%S")
+      # I'm guessing exports are locale-specific so some amount of massaging is needed
+      timestampRaw = timestampMatch[2].strip.gsub(/\//, { '/' => '.' })
 
+
+      # TODO: add command-line option to specify if we are DD/MM/YY or MM/DD/YY;
+      # or just deduce it by scanning the chat file looking for MM >12
+      if timestampMatch[3] != nil
+        strpFormat = "%d.%m.%y, %H:%M:%S %p"
+      else
+        strpFormat = "%d.%m.%y, %H:%M:%S"
+      end
+
+      timestamp = DateTime.strptime(timestampRaw, strpFormat)
+      puts "parsed " + timestamp.inspect
+     
       #
       # After the timestamp, there is usually the sender ID followed by a ":",
       # except for system messages. Assumption: system messages never contain


### PR DESCRIPTION
maybe WhatsApp has changed their chat export formatting? Anyway, this works for me